### PR TITLE
WIP Set image for container and not the deployment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   deployment-name:
     description: "Deployment name on Kubernetes"
     required: true
+  container-name:
+    description: "Name of the container to set image for"
+    required: true
   k8s-cluster-name:
     description: "Kubernetes cluster name"
     required: true
@@ -71,5 +74,5 @@ runs:
         ibmcloud ks cluster config --cluster ${{ inputs.k8s-cluster-name }}
         kubectl config current-context
         kubectl set image --namespace=${{ inputs.k8s-cluster-namespace }} deployments/${{ inputs.deployment-name }} \
-        ${{ inputs.deployment-name }}=${{ inputs.registry-hostname }}/${{ inputs.icr-namespace }}/${{ inputs.image-name }}:${{ inputs.github-sha }}
+        ${{ inputs.container-name }}=${{ inputs.registry-hostname }}/${{ inputs.icr-namespace }}/${{ inputs.image-name }}:${{ inputs.github-sha }}
       shell: bash


### PR DESCRIPTION
Currently the code assumes the `container name` is the same as the `deployment name` to set the image. This is not always true. Specially if the deployment contains multiple containers. 

@krook, ideally we keep `container-name` optional and default to `deployment-name`, but Github actions do not allow dynamic default values. It has to be a string. So this is a BREAKING change for existing repos that use this action.

FYI @EdrianI 