### PR TITLE
cloud regions are different from icr regions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "IBM Cloud Region"
     required: false
     default: "us-south"
+  icr-region:
+    description: "Container Registry Region"
+    required: false
+    default: "us-south"
   icr-namespace:
     description: "IBM Cloud Container Registry namespace"
     required: true
@@ -53,7 +57,7 @@ runs:
     - id: login-to-ibmcloud-cli
       run: |
         ibmcloud login --apikey "${{ inputs.cloud-api-key }}" -r "${{ inputs.cloud-region }}" -g "${{ inputs.cloud-resource-group }}"
-        ibmcloud cr region-set "${{ inputs.cloud-region }}"
+        ibmcloud cr region-set "${{ inputs.icr-region }}"
         ibmcloud cr login
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   deployment-name:
     description: "Deployment name on Kubernetes"
     required: true
+  container-name:
+    description: "Name of the container to set image for"
+    required: true
   k8s-cluster-name:
     description: "Kubernetes cluster name"
     required: true
@@ -71,5 +74,5 @@ runs:
         ibmcloud ks cluster config --cluster ${{ inputs.k8s-cluster-name }}
         kubectl config current-context
         kubectl set image --namespace=${{ inputs.k8s-cluster-namespace }} deployments/${{ inputs.deployment-name }} \
-        ${{ inputs.deployment-name }}=${{ inputs.registry-hostname }}/${{ inputs.icr-namespace }}/${{ inputs.image-name }}:${{ inputs.github-sha }}
+        ${{ inputs.container-name }}=${{ inputs.registry-hostname }}/${{ inputs.icr-namespace }}/${{ inputs.image-name }}:${{ inputs.github-sha }}
       shell: bash


### PR DESCRIPTION
The action currently uses single variable `inputs.cloud-region` as both the IBM Cloud region and the ICR region. The cloud region does not correspond to registry regions. I have an application in `us-east`. There is no corresponding registry region and my image sits in `us-south`. So I need to pass them in separately.

Proposed change is to add `icr-region` as another input to the action and default to `us-south`.